### PR TITLE
CORE-1058 Disable SSL pinning in iOS.

### DIFF
--- a/BNPayment/Core/Security/BNSecurity.m
+++ b/BNPayment/Core/Security/BNSecurity.m
@@ -128,7 +128,9 @@ static NSString *const OLD_MasterCert =
 
 - (BOOL)evaluateServerTrust:(SecTrustRef)serverTrust
                   forDomain:(NSString *)domain {
-    
+    //APAC remove the ssl cert pinning.
+    return YES;
+
     if (!self.pinnedCertificates || !domain || [self.pinnedCertificates count] == 0) {
         return NO;
     }
@@ -157,6 +159,8 @@ static NSString *const OLD_MasterCert =
 }
 
 + (BOOL)evaluateCert:(SecCertificateRef)certRef masterCert:(SecCertificateRef)secTrust {
+    //APAC remove the ssl cert pinning.
+    return YES;
 
     NSData *masterCertData = [MasterCert getCertData];
     


### PR DESCRIPTION
Hi Peter,

The similar changes had been reviewed in our internal repository, this is the pull request to push our internal repository changes to public.

CORE-1058 Disable SSL pinning in iOS.

Regards,
Chen